### PR TITLE
Add vue file extension on import

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,4 +1,4 @@
-import Kanban from './components/Kanban';
+import Kanban from './components/Kanban.vue';
 
 export default {
   install(vue) {


### PR DESCRIPTION
This explicitly adds the `.vue` file extension to the plugin's import statement.

Fixes #14 