### PR TITLE
Config prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and then use the component in your project.
 <kanban-board :stages="stages" :blocks="blocks"></kanban-board>
 ```
 
-#### Props
+#### Required Props
 - stages: an array of stages for the kanban board
 - blocks: an array of objects that will make up the blocks on the kanban board
 ```js
@@ -43,6 +43,19 @@ and then use the component in your project.
       title: 'Test',
     },
   ],
+}
+```
+
+### Advanced Props
+- config: an object of dragula options to be passed to the kanban board, see [dragula docs](https://github.com/bevacqua/dragula#dragulacontainers-options) for more details
+```js
+{
+  config: {
+    // Don't allow blocks to be moved out of the approved stage
+    accepts(block, target, source) {
+      return source.dataset.status !== 'approved',
+    }
+  }
 }
 ```
 

--- a/src/components/Kanban.vue
+++ b/src/components/Kanban.vue
@@ -52,9 +52,9 @@
       },
     },
 
-  updated() {
-    this.drake.containers = this.$refs.list;
-  },
+    updated() {
+      this.drake.containers = this.$refs.list;
+    },
   mounted() {
     this.drake = dragula(this.$refs.list)
       .on('drag', (el) => {
@@ -77,6 +77,6 @@
           }, 600);
         }, 100);
       });
-  }
+    },
   };
 </script>

--- a/src/components/Kanban.vue
+++ b/src/components/Kanban.vue
@@ -65,8 +65,9 @@
     updated() {
       this.drake.containers = this.$refs.list;
     },
-  mounted() {
-    this.drake = dragula(this.$refs.list)
+
+    mounted() {
+      this.drake = dragula(this.$refs.list, this.config)
       .on('drag', (el) => {
         el.classList.add('is-moving');
       })

--- a/src/components/Kanban.vue
+++ b/src/components/Kanban.vue
@@ -31,8 +31,18 @@
     name: 'KanbanBoard',
 
     props: {
-      stages: {},
-      blocks: {},
+      stages: {
+        type: Array,
+        required: true,
+      },
+      blocks: {
+        type: Array,
+        required: true,
+      },
+      config: {
+        type: Object,
+        default: {},
+      },
     },
     data() {
       return {

--- a/test/vue-kanban.spec.js
+++ b/test/vue-kanban.spec.js
@@ -4,7 +4,7 @@ import VueKanban from '../src/plugin';
 Vue.use(VueKanban);
 
 const vm = new Vue({
-  template: '<kanban-board :stages="stages" :blocks="blocks" ref="kanban"></kanban-board>',
+  template: '<kanban-board :stages="stages" :blocks="blocks" ref="kanban" :config="config"></kanban-board>',
   data() {
     return {
       stages: ['on-hold', 'in-progress', 'needs-review', 'approved'],
@@ -15,6 +15,10 @@ const vm = new Vue({
           title: 'Test',
         },
       ],
+      config: {
+        copy: true,
+        direction: 'horizontal',
+      },
     };
   },
 }).$mount();
@@ -35,6 +39,20 @@ describe('VueKanban', () => {
     it('blocks', () => {
       expect(typeof vm.$refs.kanban.blocks).toEqual('object');
       expect(vm.$refs.kanban.blocks.map(b => b.id)).toContain(1);
+    });
+
+    describe('config', () => {
+      it('should be an object', () => {
+        expect(typeof vm.$refs.kanban.config).toEqual('object');
+      });
+
+      it('should use values in prop', () => {
+        expect(vm.$refs.kanban.config.copy).toEqual(true);
+        expect(vm.$refs.kanban.config.direction).toEqual('horizontal');
+      });
+      it('should set the dragula defaults', () => {
+        expect(vm.$refs.kanban.config.copySortSource).toEqual(false);
+      });
     });
   });
 


### PR DESCRIPTION
Allows user to pass through a Dragula config prop to the component for customisation of the Kanban board's behaviour

### Proposed usage

Config object can be built up in the parent component

```js
{
  config: {
    // Don't allow blocks to be moved out of the approved stage
    accepts(block, target, source) {
      return source.dataset.status !== 'approved',
    }
  }
}
```

and passed through to component as a prop.

```html
<kanban-board :stages="stages" :blocks="blocks" :config="config"></kanban-board>
```
