### PR TITLE
Allow custom id and status prop

### DIFF
--- a/src/components/Kanban.vue
+++ b/src/components/Kanban.vue
@@ -9,10 +9,10 @@
         </span>
         <div class="drag-options"></div>
         <ul class="drag-inner-list" ref="list" :data-status="stage">
-          <li class="drag-item" v-for="block in getBlocks(stage)" :data-block-id="block.id" :key="block.id">
-            <slot :name="block.id">
-              <strong>{{ block.status }}</strong>
-              <div>{{ block.id }}</div>
+          <li class="drag-item" v-for="block in getBlocks(stage)" :data-block-id="block[idProp]" :key="block[idProp]">
+            <slot :name="block[idProp]">
+              <strong>{{ block[statusProp] }}</strong>
+              <div>{{ block[idProp] }}</div>
             </slot>
           </li>
         </ul>
@@ -48,6 +48,14 @@
         type: Object,
         default: null,
       },
+      idProp: {
+        type: String,
+        default: 'id',
+      },
+      statusProp: {
+        type: String,
+        default: 'status',
+      },
     },
 
     data() {
@@ -64,7 +72,7 @@
 
     methods: {
       getBlocks(status) {
-        return this.localBlocks.filter(block => block.status === status);
+        return this.localBlocks.filter(block => block[this.statusProp] === status);
       },
 
       findPossibleTransitions(sourceState) {
@@ -87,7 +95,7 @@
       },
 
       allowedTargets(el, source) {
-        const block = this.localBlocks.find(b => b.id === el.dataset.blockId);
+        const block = this.localBlocks.find(b => b[this.idProp] === el.dataset.blockId);
         return this.drake.containers.filter(c => this.config.accepts(block, c, source));
       },
 

--- a/src/components/Kanban.vue
+++ b/src/components/Kanban.vue
@@ -85,6 +85,15 @@
         const sourceState = source.dataset.status;
         return Object.values(this.findPossibleTransitions(sourceState)).includes(targetState);
       },
+
+      allowedTargets(el, source) {
+        const block = this.localBlocks.find(b => b.id === el.dataset.blockId);
+        return this.drake.containers.filter(c => this.config.accepts(block, c, source));
+      },
+
+      forbiddenTargets(el, source) {
+        return this.drake.containers.filter(c => !this.allowedTargets(el, source).includes(c));
+      },
     },
 
     updated() {
@@ -97,10 +106,13 @@
       .on('drag', (el, source) => {
         this.$emit('drag', el, source);
         el.classList.add('is-moving');
+        this.allowedTargets(el, source).forEach(c => c.classList.add('allowed'));
+        this.forbiddenTargets(el, source).forEach(c => c.classList.add('forbidden'));
       })
       .on('dragend', (el) => {
         this.$emit('dragend', el);
         el.classList.remove('is-moving');
+        this.drake.containers.forEach(c => c.classList.remove('allowed', 'forbidden'));
         window.setTimeout(() => {
           el.classList.add('is-moved');
           window.setTimeout(() => {


### PR DESCRIPTION
Hi BrockReece,

this is a PR to allow users to customise which properties on the block objects are used as id and status (defaulting to "id" and "status"). This is useful in cases where block.id (block.status, respectively) are already reserved for something else.

This PR is on top of https://github.com/BrockReece/vue-kanban/pull/50 because it includes changes to code added by that other PR.