### PR TITLE
Set root $el as mirror container (instead of document.body)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vue-kanban",
-  "version": "1.6.2",
+  "name": "@blackdackel/vue-kanban",
+  "version": "1.7.0",
   "description": "A Vue.js project",
   "author": "Brock <brock.reece@croud.co.uk>",
   "main": "src/plugin.js",

--- a/src/components/Kanban.vue
+++ b/src/components/Kanban.vue
@@ -9,10 +9,10 @@
         </span>
         <div class="drag-options"></div>
         <ul class="drag-inner-list" ref="list" :data-status="stage">
-          <li class="drag-item" v-for="block in getBlocks(stage)" :data-block-id="block.id" :key="block.id">
-            <slot :name="block.id">
-              <strong>{{ block.status }}</strong>
-              <div>{{ block.id }}</div>
+          <li class="drag-item" v-for="block in getBlocks(stage)" :data-block-id="block[idProp]" :key="block[idProp]">
+            <slot :name="block[idProp]">
+              <strong>{{ block[statusProp] }}</strong>
+              <div>{{ block[idProp] }}</div>
             </slot>
           </li>
         </ul>
@@ -48,6 +48,14 @@
         type: Object,
         default: null,
       },
+      idProp: {
+        type: String,
+        default: 'id',
+      },
+      statusProp: {
+        type: String,
+        default: 'status',
+      },
     },
 
     data() {
@@ -64,7 +72,7 @@
 
     methods: {
       getBlocks(status) {
-        return this.localBlocks.filter(block => block.status === status);
+        return this.localBlocks.filter(block => block[this.statusProp] === status);
       },
 
       findPossibleTransitions(sourceState) {
@@ -87,7 +95,7 @@
       },
 
       allowedTargets(el, source) {
-        const block = this.localBlocks.find(b => b.id === el.dataset.blockId);
+        const block = this.localBlocks.find(b => b[this.idProp] === el.dataset.blockId);
         return this.drake.containers.filter(c => this.config.accepts(block, c, source));
       },
 

--- a/src/components/Kanban.vue
+++ b/src/components/Kanban.vue
@@ -85,6 +85,15 @@
         const sourceState = source.dataset.status;
         return Object.values(this.findPossibleTransitions(sourceState)).includes(targetState);
       },
+
+      allowedTargets(el, source) {
+        const block = this.localBlocks.find(b => b.id === el.dataset.blockId);
+        return this.drake.containers.filter(c => this.config.accepts(block, c, source));
+      },
+
+      forbiddenTargets(el, source) {
+        return this.drake.containers.filter(c => !this.allowedTargets(el, source).includes(c));
+      },
     },
 
     updated() {
@@ -97,10 +106,13 @@
       .on('drag', (el, source) => {
         this.$emit('drag', el, source);
         el.classList.add('is-moving');
+        this.allowedTargets(el, source).forEach(c => c.classList.add('allowed'));
+        this.forbiddenTargets(el, source).forEach(c => c.classList.add('forbidden'));
       })
       .on('dragend', (el) => {
         this.$emit('dragend', el);
         el.classList.remove('is-moving');
+        this.drake.containers.forEach(c => c.classList.remove('allowed', 'forbidden'));
         window.setTimeout(() => {
           el.classList.add('is-moved');
           window.setTimeout(() => {


### PR DESCRIPTION
Hi,

this PR uses the kanban-board itself as container for the mirrored cards. By default, dragula uses document.body (which is sensible because it requires no knowledge about the DOM structure) but Vue gives us access to the DOM element that the component is mounted on, via $el. The benefit of using $el is  that the original blocks/cards and the mirrored blocks/cards are closer to each other in the DOM and CSS rules are more likely to work for originals and mirrors alike (whereas all nested CSS rules for the original cards will fail for the mirrors when attached to document.body). This makes it much easier to style the mirrors in a similar/same way as the originals, with one set of CSS rules.

However, this is a breaking change so feel to reject.