### PR TITLE
Set root $el as mirror container (instead of document.body)

### DIFF
--- a/src/components/Kanban.vue
+++ b/src/components/Kanban.vue
@@ -89,11 +89,15 @@
 
     updated() {
       this.drake.containers = this.$refs.list;
+      this.drake.mirrorContainer = this.$el;
     },
 
     mounted() {
       this.config.accepts = this.config.accepts || this.accepts;
-      this.drake = dragula(this.$refs.list, this.config)
+      this.drake = dragula(this.$refs.list, {
+        ...this.config,
+        mirrorContainer: this.$el,
+      })
       .on('drag', (el, source) => {
         this.$emit('drag', el, source);
         el.classList.add('is-moving');

--- a/src/components/Kanban.vue
+++ b/src/components/Kanban.vue
@@ -94,10 +94,8 @@
 
     mounted() {
       this.config.accepts = this.config.accepts || this.accepts;
-      this.drake = dragula(this.$refs.list, {
-        ...this.config,
-        mirrorContainer: this.$el,
-      })
+      this.config.mirrorContainer = this.$el;
+      this.drake = dragula(this.$refs.list, this.config)
       .on('drag', (el, source) => {
         this.$emit('drag', el, source);
         el.classList.add('is-moving');


### PR DESCRIPTION
Hi,

this PR uses the kanban-board itself as container for the mirrored cards. By default, dragula uses document.body (which is sensible because it requires no knowledge about the DOM structure) but Vue gives us access to the DOM element that the component is mounted on, via $el. The benefit of using $el is that the original blocks/cards and the mirrored blocks/cards are closer to each other in the DOM and CSS rules are more likely to work for originals and mirrors alike (whereas all nested CSS rules for the original cards will fail for the mirrors when attached to document.body). This makes it much easier to style the mirrors in a similar/same way as the originals, with one set of CSS rules.